### PR TITLE
Move link prompt submit action to submit button

### DIFF
--- a/addon/components/mobiledoc-link-prompt/template.hbs
+++ b/addon/components/mobiledoc-link-prompt/template.hbs
@@ -1,5 +1,5 @@
-<form {{action attrs.on-submit href on="submit"}}>
+<form>
   {{input value=href}}
-  <button type="submit">Link</button>
+  <button {{action attrs.on-submit href}} type="submit">Link</button>
   <button {{action attrs.on-cancel}}>Cancel</button>
 </form>


### PR DESCRIPTION
Currently, if the editor is inside a form, you cannot create a link because the page will refresh when you click submit inside the link prompt.

Thoughts on moving the submit action out of the form element?

Open issue #2.