### PR TITLE
Upgrade mobiledoc-kit dep, use editor#toggleMarkup

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -117,10 +117,8 @@ export default Component.extend({
       let offsets = this.get('linkOffsets');
       this.set('linkOffsets', null);
       let editor = this.get('editor');
-      editor.run(postEditor => {
-        let markup = postEditor.builder.createMarkup('a', {href});
-        postEditor.addMarkupToRange(offsets, markup);
-      });
+      editor.selectRange(offsets);
+      editor.toggleMarkup('a', {href});
     },
 
     cancelLink() {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-htmlbars": "^2.0.3",
     "ember-wormhole": "^0.5.1",
     "mobiledoc-dom-renderer": "^0.6.5",
-    "mobiledoc-kit": "^0.10.15"
+    "mobiledoc-kit": "^0.10.17"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -35,7 +35,7 @@
     "ember-cli": "^2.14.2",
     "ember-cli-dependency-checker": "^2.0.1",
     "ember-cli-eslint": "^4.2.0",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1993,9 +1993,9 @@ ember-cli-get-dependency-depth@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-dependency-depth/-/ember-cli-get-dependency-depth-1.0.0.tgz#e0afecf82a2d52f00f28ab468295281aec368d11"
 
-ember-cli-htmlbars-inline-precompile@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.1.tgz#bb7462af2e79fc3e4406c0c626f9f9690fa5d985"
+ember-cli-htmlbars-inline-precompile@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.2.tgz#5b544f664d5d9911f08cd979c5f70d8cb0ca2add"
   dependencies:
     babel-plugin-htmlbars-inline-precompile "^0.2.3"
     ember-cli-version-checker "^2.0.0"
@@ -4005,9 +4005,9 @@ mobiledoc-dom-renderer@0.6.5, mobiledoc-dom-renderer@^0.6.5:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/mobiledoc-dom-renderer/-/mobiledoc-dom-renderer-0.6.5.tgz#56c0302c4f9c30840ab5b9b20dfe905aed1e437b"
 
-mobiledoc-kit@^0.10.15:
-  version "0.10.16"
-  resolved "https://registry.yarnpkg.com/mobiledoc-kit/-/mobiledoc-kit-0.10.16.tgz#09ed6f5a48dca497e265690a41be94a6baa3e24a"
+mobiledoc-kit@^0.10.17:
+  version "0.10.17"
+  resolved "https://registry.yarnpkg.com/mobiledoc-kit/-/mobiledoc-kit-0.10.17.tgz#1362b4b664eaaa2aae44778e03b23f8ed1248169"
   dependencies:
     mobiledoc-dom-renderer "0.6.5"
     mobiledoc-text-renderer "0.3.2"


### PR DESCRIPTION
Using `editor#toggleMarkup` allows addon consumers to use the new (as of
mobiledoc-kit@0.10.17) `editor#beforeToggleMarkup` hook to add their own
validations of schema and, e.g., validating URLs before writers can link
them.