### PR TITLE
Include mobiledoc-dom-renderer source map

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ module.exports = {
     if (rendererDir) {
       files.push(new Funnel(rendererDir, {
         files: [
-          'amd/mobiledoc-dom-renderer.js'
+          'amd/mobiledoc-dom-renderer.js',
+          'amd/mobiledoc-dom-renderer.map'
         ],
         destDir: 'mobiledoc-dom-renderer'
       }));


### PR DESCRIPTION
As you can see in the lines above, ember-mobiledoc-editor includes both the AMD JavaScript and accompanying source map for mobiledoc-kit but not for mobiledoc-dom-renderer. This PR updates the Broccoli plugin to include the source map for mobiledoc-dom-renderer as well.