### PR TITLE
Fallback to parent coords in `tether-to-selection`

### DIFF
--- a/addon/components/tether-to-selection/component.js
+++ b/addon/components/tether-to-selection/component.js
@@ -20,6 +20,8 @@ export default Component.extend({
 
     if (range) {
       let rect = range.getBoundingClientRect();
+      // Fallback on parent element container if no anchor container found:
+      if (!rect.left && !rect.top) rect = range.startContainer.getBoundingClientRect()
       this.set('left', rect.left);
       this.set('top', rect.top);
     }


### PR DESCRIPTION
A user reported that the link prompt was always offscreen. I traced this down to `range.getBoundingClient()` returning zero for dimensions and coords in certain cases—I was able to duplicate most reliably by opening a blank editor, hitting “enter”, hitting the “up” key, and finally hitting the link button.

Cases that trigger the issue seemed more prevalent in release Safari than in release Chrome for whatever reason. I could not find the root “cause” of the zeroed-out attributes, but found that falling back to `startContainer` works fine from a UI perspective—so, admittedly, this is a case of treating the symptom…