### PR TITLE
Pass showLinkTooltips option to editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The component accepts these arguments:
   to use atoms with Ember components.
 * `spellcheck` boolean
 * `autofocus` boolean
+* `showLinkTooltips` boolean
 * `placeholder` string -- the placeholder text to display when the mobiledoc is blank
 * `options` hash -- any properties in the `options` hash will be passed to the MobiledocKitEditor constructor
 * `serializeVersion` string -- The mobiledoc version to serialize to when firing the on-change action. Default: 0.3.2

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -54,6 +54,7 @@ export default Component.extend({
   placeholder: 'Write here...',
   spellcheck: true,
   autofocus: true,
+  showLinkTooltips: true,
   serializeVersion: MOBILEDOC_VERSION,
 
   options: null,
@@ -63,12 +64,13 @@ export default Component.extend({
     let options = this.get('options') || {};
 
     return assign({
-      placeholder: this.get('placeholder'),
-      spellcheck:  this.get('spellcheck'),
-      autofocus:   this.get('autofocus'),
-      cardOptions: this.get('cardOptions'),
-      cards:       this.get('cards') || [],
-      atoms:       this.get('atoms') || []
+      placeholder:      this.get('placeholder'),
+      spellcheck:       this.get('spellcheck'),
+      autofocus:        this.get('autofocus'),
+      showLinkTooltips: this.get('showLinkTooltips'),
+      cardOptions:      this.get('cardOptions'),
+      cards:            this.get('cards') || [],
+      atoms:            this.get('atoms') || []
     }, options);
   }),
 


### PR DESCRIPTION
Sibling PR to https://github.com/bustle/mobiledoc-kit/pull/602. Allow the editor to disabled link tooltips. 

We're building out an interface that brings up the link prompt whenever a link is selected or clicked on. The tooltips are redundant and it would be nice to easily disable them. 