### PR TITLE
Add cursorDidChange callback to editor compo

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -258,6 +258,12 @@ export default Component.extend({
         this.inputModeDidChange(editor);
       });
     });
+    editor.cursorDidChange(() => {
+      if (this.isDestroyed) { return; }
+      join(() => {
+        this.cursorDidChange(editor);
+      });
+    });
     if (this.get('isEditingDisabled')) {
       editor.disableEditing();
     }
@@ -314,6 +320,10 @@ export default Component.extend({
       this.set('activeMarkupTagNames', markupTags);
       this.set('activeSectionTagNames', sectionTags);
     }
+  },
+
+  cursorDidChange(editor) {
+
   },
 
   willCreateEditor() {

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -322,7 +322,7 @@ export default Component.extend({
     }
   },
 
-  cursorDidChange(editor) {
+  cursorDidChange(/*editor*/) {
 
   },
 


### PR DESCRIPTION
We've run into issues where the `inputModeDidChange` callback wasn't firing at times when we wanted it to. `cursorDidChange` seems to do exactly what we want. We're implementing an interface that shows a link tooltip/prompt when you click on the link, rather than hover on it. I saw that you removed this in https://github.com/bustle/ember-mobiledoc-editor/pull/69, so I'm not sure if you want it back or not. 

I'm up for discussion about how to implement and test this. We're doing most of our work in a subclass of `mobiledoc-editor` and so in this PR it's just setting up the callback and an empty method.

Here is what our interface is looking like at the moment:
![mobiledoc-editor-tooltip](https://user-images.githubusercontent.com/9383/36736036-962a2178-1ba5-11e8-8538-76a346ab6913.gif)
