### PR TITLE
Throw editor render errors after runloop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-lts-2.8
     - EMBER_TRY_SCENARIO=ember-lts-2.12
     - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-3.0
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary

--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -270,7 +270,11 @@ export default Component.extend({
     if (!editor.hasRendered) {
       let editorElement = this.$('.mobiledoc-editor__editor')[0];
       this._isRenderingEditor = true;
-      editor.render(editorElement);
+      try {
+        editor.render(editorElement);
+      } catch(e) {
+        run.schedule('afterRender', () => { throw e; });
+      }
       this._isRenderingEditor = false;
     }
     this._setExpandoProperty(editor);

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -58,6 +58,14 @@ module.exports = {
       }
     },
     {
+      name: 'ember-3.0',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.0.0'
+        }
+      }
+    },
+    {
       name: 'ember-lts-2.16',
       npm: {
         devDependencies: {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.18.0",
+    "ember-source": "~3.0.0",
     "eslint-plugin-ember": "^5.0.3",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"

--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -331,16 +331,21 @@ test('toolbar buttons can be active', function(assert) {
     {{/mobiledoc-editor}}
   `);
   const textNode = this.$(`p:contains(${text})`)[0].firstChild;
+
+  const button = this.$(`button[title=Heading]`);
   return selectRange(textNode, 0, textNode, text.length).then(() => {
-    const button = this.$(`button[title=Heading]`);
     assert.ok(button.length, 'has heading toolbar button');
     button.click();
 
+    return wait();
+  }).then(() => {
     assert.ok(this.$(`h1:contains(${text})`).length, 'heading-ifies text');
     assert.ok(button.hasClass('active'), 'heading button is active');
 
     button.click();
 
+    return wait();
+  }).then(() => {
     assert.ok(!this.$(`h1`).length, 'heading is gone');
     assert.ok(!button.hasClass('active'), 'heading button is no longer active');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,9 +2402,9 @@ ember-router-generator@^1.0.0, ember-router-generator@^1.2.3:
   dependencies:
     recast "^0.11.3"
 
-ember-source@~2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.18.0.tgz#f61cf2701d8aa94a6adee6d47b1d5a73a4cef5f6"
+ember-source@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.0.0.tgz#51811cae98d2ceec53bcfbaa876d02b2b5b2159f"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
@@ -2413,7 +2413,6 @@ ember-source@~2.18.0:
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-test-info "^1.0.0"
     ember-cli-valid-component-name "^1.0.0"
     ember-cli-version-checker "^2.1.0"
     ember-router-generator "^1.2.3"


### PR DESCRIPTION
In Ember 3.0+ glimmer's internals get caught up on the error that
`editor.render` throws and `assert.throws` gets triggered with a
different error: "Cannot read property 'commit' of null"

Also: Add Ember 3.0 as an ember-try target.

Fixes the build at Travis.