### PR TITLE
Move away from deprecated sendAction function

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -337,7 +337,10 @@ export default Component.extend({
     let serializeVersion = this.get('serializeVersion');
     let updatedMobileDoc = editor.serialize(serializeVersion);
     this._localMobiledoc = updatedMobileDoc;
-    this.sendAction('on-change', updatedMobileDoc); // eslint-disable-line ember/closure-actions
+
+    if (this['on-change']) {
+      this['on-change'](updatedMobileDoc);
+    }
   },
 
   inputModeDidChange(editor) {
@@ -397,11 +400,15 @@ export default Component.extend({
   },
 
   willCreateEditor() {
-    this.sendAction(WILL_CREATE_EDITOR_ACTION); // eslint-disable-line ember/closure-actions
+    if (this[WILL_CREATE_EDITOR_ACTION]) {
+      this[WILL_CREATE_EDITOR_ACTION]();
+    }
   },
 
   didCreateEditor(editor) {
-    this.sendAction(DID_CREATE_EDITOR_ACTION, editor); // eslint-disable-line ember/closure-actions
+    if (this[DID_CREATE_EDITOR_ACTION]) {
+      this[DID_CREATE_EDITOR_ACTION](editor);
+    }
   },
 
   _addAtom(atomName, text, payload) {


### PR DESCRIPTION
This closes #160. I followed the deprecation guidelines here:
https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_ember-component-send-action

To show that this actually works to remove the deprecation warning in newer Ember versions that aren’t currently being tested, I made another branch that merged both this one and #162; [this Travis job log](https://travis-ci.com/backspace/ember-mobiledoc-editor/jobs/156848621) doesn’t contain the warning that I linked to in #162.

There are some judgment calls in this implementation that I made arbitrarily. For instance, rather than specifying empty implementations for the three actions, I could have checked for their existence before calling them, as [in the guidelines](https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_ember-component-send-action). I‘ve also seen some addons throw exceptions when an action isn’t supplied, which I wondered whether may be applicable for `on-change`, but it seemed unnecessary to me.

Let me know if you have any changes you’d like to see and thanks for all the work on this!