### PR TITLE
Add a class to the div wrapping a card

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -171,6 +171,7 @@ export default Component.extend({
         let destinationElementId = `mobiledoc-editor-card-${cardId}`;
         let element = document.createElement('div');
         element.id = destinationElementId;
+        element.className = 'mobiledoc-editor__card-wrapper';
 
         // The data must be copied to avoid sharing the reference
         payload = copy(payload, true);


### PR DESCRIPTION
Allows easier targeting of the div for styling by the consumer. 
I found I needed to give this div a width and it was hard to target without a class.