### PR TITLE
fix: error thrown because didCreateEditor is called too early

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -268,6 +268,10 @@ export default Component.extend({
       editor.disableEditing();
     }
     this.set('editor', editor);
+  },
+
+  didInsertElement() {
+    let editor = this.get('editor');
     this.didCreateEditor(editor);
   },
 

--- a/tests/integration/components/mobiledoc-editor/component-test.js
+++ b/tests/integration/components/mobiledoc-editor/component-test.js
@@ -110,6 +110,39 @@ test(`fires ${WILL_CREATE_EDITOR_ACTION} and ${DID_CREATE_EDITOR_ACTION} actions
   `);
 });
 
+test(`mobiledoc-editor component exists in DOM when ${DID_CREATE_EDITOR_ACTION} action is called`, function(assert) {
+  assert.expect(1);
+
+  this.set('mobiledoc', simpleMobileDoc('hello'));
+  this.on('didCreateEditor', () => {
+    assert.equal(this.$('.mobiledoc-editor').length, 1, 'mobiledoc-editor component exists in DOM');
+  });
+
+  this.render(hbs`
+    {{#mobiledoc-editor mobiledoc=mobiledoc
+                        did-create-editor=(action "didCreateEditor")}}
+    {{/mobiledoc-editor}}
+  `);
+});
+
+test(`does not throw a 'modified "editor" twice in a single render' error`, function(assert) {
+  assert.expect(1);
+
+  this.set('mobiledoc', simpleMobileDoc('hello'));
+  this.on('didCreateEditor', (_editor) => {
+    this.set('editor', _editor);
+  });
+
+  this.render(hbs`
+    {{editor}} {{!-- this line must be above the mobiledoc-editor component for this test --}}
+    {{#mobiledoc-editor mobiledoc=mobiledoc
+                        did-create-editor=(action "didCreateEditor")}}
+    {{/mobiledoc-editor}}
+  `);
+
+  assert.ok(true, `an error is not thrown`);
+});
+
 test('it does not create a new editor when the same mobiledoc is set', function(assert) {
   assert.expect(4);
   let mobiledoc = simpleMobileDoc('Howdy');


### PR DESCRIPTION
**Overview**
The `didCreateEditor` lifecycle hook is being called in `willRender`. This is throwing an EmberError when the `editor` provided by `didCreateEditor` is used elsewhere.

**Reproduction**
Link: https://ember-twiddle.com/4ba3fad7bcc64119fcfb324f8bf770ac
Open console to see error message.
>Assertion Failed: You modified "editor" twice on <twiddle@controller:application::ember177> in a single render. It was rendered in "template:twiddle/templates/application" and modified in "component:mobiledoc-editor". This was unreliable and slow in Ember 1.x and is no longer supported. See https://github.com/emberjs/ember.js/issues/13948 for more details.

**Solution**
Move the `didCreateEditor` call to `didInsertElement`
