### PR TITLE
rm jquery usage from editor

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -274,7 +274,7 @@ export default Component.extend({
   didRender() {
     let editor = this.get('editor');
     if (!editor.hasRendered) {
-      let editorElement = this.$('.mobiledoc-editor__editor')[0];
+      let editorElement = this.element.querySelector('.mobiledoc-editor__editor');
       this._isRenderingEditor = true;
       try {
         editor.render(editorElement);


### PR DESCRIPTION
Just discovered mobiledoc project and this addon makes it so easy, thanks!!

This is super small PR removing jquery usage from `mobiledoc-editor` component.js so I can use it in my jquery disabled app, I was also thinking in running [this codemod](https://github.com/simonihmig/ember-native-dom-helpers-codemod) to remove usage in tests