### PR TITLE
refactor: refactor jQuery usages to element selectors

### DIFF
--- a/addon/components/mobiledoc-editor/component.js
+++ b/addon/components/mobiledoc-editor/component.js
@@ -316,7 +316,7 @@ export default Component.extend({
   didRender() {
     let editor = this.get('editor');
     if (!editor.hasRendered) {
-      let editorElement = this.$('.mobiledoc-editor__editor')[0];
+      let editorElement = this.element.querySelector('.mobiledoc-editor__editor');
       this._isRenderingEditor = true;
       try {
         editor.render(editorElement);

--- a/addon/components/mobiledoc-link-prompt/component.js
+++ b/addon/components/mobiledoc-link-prompt/component.js
@@ -5,6 +5,6 @@ export default Component.extend({
   layout,
 
   didInsertElement() {
-    this.$('input').focus();
+    this.element.querySelector('input').focus();
   }
 });

--- a/addon/components/tether-to-selection/component.js
+++ b/addon/components/tether-to-selection/component.js
@@ -53,13 +53,13 @@ export default Component.extend({
       let isOffscreen = isOutOfBounds(dialogRect, boundingRect);
       if (isOffscreen) {
         let dialogAnchor = this.get('dialogAnchor');
-        this.$().css({
-          position: 'fixed',
-          left: isOffscreen.left ? DIALOG_MARGIN : (isOffscreen.right ? 'auto' : dialogAnchor.left),
-          right: isOffscreen.right ? DIALOG_MARGIN : 'auto',
-          top: isOffscreen.top ? DIALOG_MARGIN : 'auto',
-          bottom: isOffscreen.bottom ? DIALOG_MARGIN : (isOffscreen.top ? 'auto' : dialogAnchor.bottom)
-        });
+        this.element.setAttribute('style', `
+          position: 'fixed';
+          left: ${isOffscreen.left ? DIALOG_MARGIN : (isOffscreen.right ? 'auto' : dialogAnchor.left)};
+          right: ${isOffscreen.right ? DIALOG_MARGIN : 'auto'};
+          top: ${isOffscreen.top ? DIALOG_MARGIN : 'auto'};
+          bottom: ${isOffscreen.bottom ? DIALOG_MARGIN : (isOffscreen.top ? 'auto' : dialogAnchor.bottom)};
+        `);
       }
     });
   }


### PR DESCRIPTION
Octane apps consuming this addon will throw the following error:

> 2vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:15812 Uncaught TypeError: (0 , a.jQuery) is not a function
    at c.s.JQUERY_INTEGRATION.l.$ (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:15812)
    at c.didRender (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:61007)
    at c.trigger (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:16196)
    at c.r [as trigger] (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:15197)
    at n.i.didCreate (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:5676)
    at e.t.commit (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:23477)
    at e.r.commit (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:23575)
    at Be (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:23681)
    at r.i._renderRoots (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:8235)
    at r.i._renderRootsTransaction (vendor-e1f3e6c162fd0a87c91ac02da93f94a2.js:formatted:8257)

This PR removes the deprecated jQuery selectors in favour of "native", classic Ember selectors using `this.element`.

Later on, I plan on submitting another MR which migrates this addon to octane.