### PR TITLE
Update engine version to the one that allows yarn install to succeed

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "release-it-lerna-changelog": "^2.3.0"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "^10.* || >= 11.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -78,5 +78,9 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
+  },
+  "volta": {
+    "node": "10.24.1",
+    "yarn": "1.22.19"
   }
 }


### PR DESCRIPTION
Require node 10 or higher
Node 10 is archaic, but we're bumping it up from v6, so... baby steps!